### PR TITLE
Limit where token is accesible

### DIFF
--- a/.github/actions/commit-release/action.yml
+++ b/.github/actions/commit-release/action.yml
@@ -4,10 +4,23 @@ inputs:
   version:
     description: "Release version"
     required: true
+  ANTTIHARJU_BOT_ID:
+    description: "GitHub App ID for committing the release"
+    required: true
+  ANTTIHARJU_BOT_PRIVATE_KEY:
+    description: "GitHub App private key for committing the release"
+    required: true
 
 runs:
   using: "composite"
   steps:
+    - name: Generate commit token
+      uses: actions/create-github-app-token@v1
+      id: generate
+      with:
+        app-id: ${{ inputs.ANTTIHARJU_BOT_ID }}
+        private-key: ${{ inputs.ANTTIHARJU_BOT_PRIVATE_KEY }}
+        repositories: ${{ github.event.repository.name }}
     - name: Create release commit
       env:
         version: ${{ inputs.version }}

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -107,19 +107,9 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ github.token }}
     steps:
-      - if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch && !endsWith(github.actor, '[bot]')
-        name: Generate commit token
-        uses: actions/create-github-app-token@v1
-        id: generate
-        with:
-          app-id: ${{ secrets.ANTTIHARJU_BOT_ID }}
-          private-key: ${{ secrets.ANTTIHARJU_BOT_PRIVATE_KEY }}
-          repositories: ${{ github.event.repository.name }}
       - name: Find changes
         id: changes
         uses: anttiharju/find-changes-action@v1
-        with:
-          token: ${{ steps.generate.outputs.token || github.token }}
 
       - name: Detect changes
         id: changed
@@ -207,6 +197,8 @@ jobs:
         uses: ./.github/actions/commit-release
         with:
           version: ${{ steps.semantic.outputs.version }}
+          ANTTIHARJU_BOT_ID: ${{ secrets.ANTTIHARJU_BOT_ID }}
+          ANTTIHARJU_BOT_PRIVATE_KEY: ${{ secrets.ANTTIHARJU_BOT_PRIVATE_KEY }}
     outputs:
       version: ${{ steps.semantic.outputs.version }}
       documentation_changed: ${{ steps.changed.outputs.documentation }}


### PR DESCRIPTION
Embedding it into checkout is neat, but I'd like to not give everything access to it