### PR TITLE
Fix toml-cli Cargo lock update

### DIFF
--- a/.github/actions/commit-release/action.yml
+++ b/.github/actions/commit-release/action.yml
@@ -34,7 +34,7 @@ runs:
       run: |
         git reset --hard && git clean -df
         toml set Cargo.toml package.version "$version" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-        toml set Cargo.lock package.version "$version" > Cargo.lock.tmp && mv Cargo.lock.tmp Cargo.lock
+        toml set Cargo.lock "package[0].version" "$version" > Cargo.lock.tmp && mv Cargo.lock.tmp Cargo.lock
     - name: Commit changes
       uses: anttiharju/actions/commit-changes@v0
       with:


### PR DESCRIPTION
Manually updating Cargo.lock is a bit cursed, but it's what I'm going with for now

works as expected now:

```sh
toml set Cargo.lock "package[0].version" "0.1.9" > Cargo.lock.tmp && mv Cargo.lock.tmp Cargo.lock && git diff
```

```diff
diff --git a/Cargo.lock b/Cargo.lock
index c457512..4ea8209 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4

 [[package]]
 name = "compare-changes"
-version = "0.1.8"
+version = "0.1.9"
```