### PR TITLE
Robust `Cargo.lock` compare-changes version updates

### DIFF
--- a/.github/actions/commit-release/action.yml
+++ b/.github/actions/commit-release/action.yml
@@ -35,7 +35,7 @@ runs:
       run: |
         git reset --hard && git clean -df
         toml set Cargo.toml package.version "$version" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-        cargo update -p "$package"
+        cargo update --package "$package"
         yq -i ".inputs.version.default = \"$version\"" action.yml
     - name: Commit changes
       uses: anttiharju/actions/commit-changes@v0


### PR DESCRIPTION
`toml-cli` was updating the wrong version in Cargo.lock