### PR TITLE
Enable flakes in CI container

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -174,9 +174,9 @@
               mkdir -p /tmp
               chmod 1777 /tmp
 
-              # Enable nix-command experimental feature
+              # Enable 'nix eval .#container_version --raw' and 'nix flake update' inside the container
               mkdir -p /etc/nix
-              echo "experimental-features = nix-command" > /etc/nix/nix.conf
+              echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
             '';
           };
         }


### PR DESCRIPTION
Had a failure on release due to the addition of `nix flake update`. This should fix the issue.