### PR TITLE
Bundle dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      cargo:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This is annoying to update because I don't know the real behaviour until some dependency receives an update. Feedback loop is usually weeks.

I know I _could_ downgrade some deps and set the interval to days, but that's also cumbersome.