### PR TITLE
Remove unnecessary cargo login command, 

### DIFF
--- a/.github/actions/release/crate/action.yml
+++ b/.github/actions/release/crate/action.yml
@@ -12,5 +12,4 @@ runs:
       env:
         CARGO_REGISTRY_TOKEN: ${{ inputs.cargo_registry_token }}
       run: |
-        cargo login
         cargo publish --all-features


### PR DESCRIPTION
publish can read env var directly