### PR TITLE
Prune dependency graph

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -11,7 +11,7 @@ runs:
         # Hardcode version to 0.0.0 to have a stable hash when dependencies have not changed
         toml set Cargo.toml package.version "0.0.0" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
         cargo update --package ${GITHUB_REPOSITORY#*/}
-        HASH=$(cat Cargo.toml Cargo.lock flake.nix flake.lock | hashsum --sha256 --no-names)
+        HASH=$(cat Cargo.toml Cargo.lock flake.nix flake.lock | sha256sum | cut -d ' ' -f1)
         git checkout -- Cargo.toml Cargo.lock
         echo "hash=$HASH"
         echo "hash=$HASH" >> $GITHUB_OUTPUT

--- a/.github/actions/semver-label/action.yml
+++ b/.github/actions/semver-label/action.yml
@@ -82,7 +82,7 @@ runs:
         GH_TOKEN: ${{ github.token }}
       run: |
         if [ -f Cargo.toml ]; then
-          version=$(yq '.package.version' Cargo.toml)
+          version=$(toml get Cargo.toml package.version --raw)
         else
           version=$(gh release view --json name -q '.name' 2>/dev/null || echo '0.0.0')
         fi

--- a/.release/action/values.sh
+++ b/.release/action/values.sh
@@ -9,5 +9,5 @@ capture() {
 capture PKG_FILENAME action
 capture PKG_EXTENSION yml
 repo_root="$(git rev-parse --show-toplevel)"
-version="$(yq -p toml -oy '.package.version' "$repo_root/Cargo.toml")"
+version="$(toml get "$repo_root/Cargo.toml" package.version --raw)"
 capture PKG_VERSION "$version"

--- a/.release/brew/values.sh
+++ b/.release/brew/values.sh
@@ -10,7 +10,7 @@ repo="${GITHUB_REPOSITORY##*/}"
 capture PKG_FILENAME "$repo"
 capture PKG_EXTENSION rb
 capture PKG_REPO "$repo"
-class="$(echo "$repo" | awk -F'-' '{for(i=1;i<=NF;i++) printf "%s%s", toupper(substr($i,1,1)), substr($i,2)}')"
+class="$(echo "$repo" | gawk -F'-' '{for(i=1;i<=NF;i++) printf "%s%s", toupper(substr($i,1,1)), substr($i,2)}')"
 capture PKG_CLASS "$class"
 desc="$(gh repo view --json description --jq .description)"
 capture PKG_DESC "$desc"

--- a/.release/brew/values.sh
+++ b/.release/brew/values.sh
@@ -17,7 +17,7 @@ capture PKG_DESC "$desc"
 homepage="$(gh api "repos/$GITHUB_REPOSITORY" --jq .homepage)"
 capture PKG_HOMEPAGE "$homepage"
 repo_root="$(git rev-parse --show-toplevel)"
-version="$(yq -p toml -oy '.package.version' "$repo_root/Cargo.toml")"
+version="$(toml get "$repo_root/Cargo.toml" package.version --raw)"
 capture PKG_VERSION "$version"
 capture PKG_OWNER "${GITHUB_REPOSITORY%%/*}"
 

--- a/.release/brew/values.sh
+++ b/.release/brew/values.sh
@@ -36,9 +36,9 @@ gh release download "$tag" --pattern "$pattern" --clobber
 for archive in $pattern; do
   echo "# $archive"
 done
-mac_arm_sha="$([[ -f "$repo-aarch64-apple-darwin.tar.gz" ]] && hashsum --sha256 "$repo-aarch64-apple-darwin.tar.gz" --no-names || echo "TBD")"
+mac_arm_sha="$([[ -f "$repo-aarch64-apple-darwin.tar.gz" ]] && sha256sum "$repo-aarch64-apple-darwin.tar.gz" | cut -d ' ' -f1 || echo "TBD")"
 capture PKG_MAC_ARM_SHA "$mac_arm_sha"
-linux_arm_sha="$([[ -f "$repo-aarch64-unknown-linux-musl.tar.gz" ]] && hashsum --sha256 "$repo-aarch64-unknown-linux-musl.tar.gz" --no-names || echo "TBD")"
+linux_arm_sha="$([[ -f "$repo-aarch64-unknown-linux-musl.tar.gz" ]] && sha256sum "$repo-aarch64-unknown-linux-musl.tar.gz" | cut -d ' ' -f1 || echo "TBD")"
 capture PKG_LINUX_ARM_SHA "$linux_arm_sha"
-linux_intel_sha="$([[ -f "$repo-x86_64-unknown-linux-musl.tar.gz" ]] && hashsum --sha256 "$repo-x86_64-unknown-linux-musl.tar.gz" --no-names || echo "TBD")"
+linux_intel_sha="$([[ -f "$repo-x86_64-unknown-linux-musl.tar.gz" ]] && sha256sum "$repo-x86_64-unknown-linux-musl.tar.gz" | cut -d ' ' -f1 || echo "TBD")"
 capture PKG_LINUX_INTEL_SHA "$linux_intel_sha"

--- a/.release/nix/values.sh
+++ b/.release/nix/values.sh
@@ -11,7 +11,7 @@ capture PKG_FILENAME "default"
 capture PKG_EXTENSION nix
 capture PKG_REPO "$repo"
 repo_root="$(git rev-parse --show-toplevel)"
-version="$(yq -p toml -oy '.package.version' "$repo_root/Cargo.toml")"
+version="$(toml get "$repo_root/Cargo.toml" package.version --raw)"
 capture PKG_VERSION "$version"
 capture PKG_OWNER "${GITHUB_REPOSITORY%%/*}"
 capture PKG_REV "$GITHUB_SHA"

--- a/.release/render.sh
+++ b/.release/render.sh
@@ -36,7 +36,7 @@ mock_github_actions_env() {
   export GITHUB_REPOSITORY="$owner/$repo"
 
   repo_root="$(git rev-parse --show-toplevel)"
-  tag="v$(yq -p toml -oy '.package.version' "$repo_root/Cargo.toml")"
+  tag="v$(toml get "$repo_root/Cargo.toml" package.version --raw)"
   if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$tag" &>/dev/null; then
     rev="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$tag" --jq '.object.sha')"
   else

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,6 @@
           rubocop
           shellcheck
           gh
-          yq-go
           ripgrep
           # Everything below is required by GitHub Actions
           uutils-coreutils-noprefix

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,6 @@
           rubocop
           shellcheck
           gh
-          ripgrep
           # Everything below is required by GitHub Actions
           uutils-coreutils-noprefix
           bash

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
           editorconfig-checker
           (python313.withPackages (
             ps: with ps; [
-              mkdocs-material
+              mkdocs-material # TODO: switch to zensical. Note that find-changes action is python-based, so that needs to be rewritten.
             ]
           ))
           prettier

--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
           shellcheck
           gh
           # Everything below is required by GitHub Actions
-          uutils-coreutils-noprefix
+          coreutils
           bash
           gitMinimal # With plain 'git' perl etc. get bundled in
           findutils

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
           jq
           gzip
           envsubst
-          gawkInteractive
+          gawk
           xz
           gnugrep
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -72,7 +72,7 @@
           # Everything below is required by GitHub Actions
           uutils-coreutils-noprefix
           bash
-          git
+          gitMinimal # With plain 'git' perl etc. get bundled in
           findutils
           gnutar
           curl


### PR DESCRIPTION
Just try to minimise the number of packages that get installed. It's real nice that nix deduplicates a bunch of things

main method was

```
nix-store --query --tree $(nix build .#devShells.aarch64-darwin.default --print-out-paths --no-link) | sed 's|/nix/store/[a-z0-9]*-||g' | code -
```

and reasoning about it