### PR TITLE
Drop misguided --offline flag usage

### DIFF
--- a/.github/actions/release/crate/action.yml
+++ b/.github/actions/release/crate/action.yml
@@ -14,7 +14,7 @@ runs:
       run: |
         version="${tag#v}"
         toml set Cargo.toml package.version "$version" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-        cargo update --offline --package "${GITHUB_REPOSITORY#*/}"
+        cargo update --package "${GITHUB_REPOSITORY#*/}"
 
 #    - name: Authenticate
 #      id: auth

--- a/.github/actions/release/github/action.yml
+++ b/.github/actions/release/github/action.yml
@@ -20,7 +20,7 @@ runs:
       run: |
         version="${tag#v}"
         toml set Cargo.toml package.version "$version" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-        cargo update --offline --package "${GITHUB_REPOSITORY#*/}"
+        cargo update --package "${GITHUB_REPOSITORY#*/}"
     - name: Create aarch64-apple-darwin archive
       shell: sh
       run: |


### PR DESCRIPTION
```
Prepare all required actions
Run ./.github/actions/release/github
Run git tag "$tag"
Run version="${tag#v}"
error: no matching package named `anstyle` found
location searched: crates.io index
required by package `compare-changes v0.9.2 (/__w/compare-changes/compare-changes)`
note: offline mode (via `--offline`) can sometimes cause surprising resolution failures
help: if this error is too confusing you may wish to retry without `--offline`
```