### PR TITLE
Zensical strict mode

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,3 @@
 <!--major-release-->
 <!--minor-release-->
 <!--patch-release ('dependencies' label is treated the same)-->
-<!--no-release-->

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -240,7 +240,7 @@ jobs:
 
       - if: always() && !cancelled() && (steps.changed.outputs.zensical == 'true' || github.event_name == 'push')
         name: zensical
-        run: zensical build
+        run: zensical build --strict
 
       - if: always() && !cancelled() && (steps.changed.outputs.prettier == 'true' || github.event_name == 'push')
         name: prettier

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 compare-changes is a CLI and a library:
 
-1. The CLI can be used together with [find-changes-action](https://github.com/anttiharju/find-changes-action) to run GitHub Actions jobs or steps conditionally, while benefitting from static validation for the defined paths via [action-validator](https://github.com/mpalmer/action-validator) [it even uses this library since v0.9.0, so results should be 1:1!]. For more information, view the action on [GitHub Actions Marketplace](https://github.com/marketplace/actions/compare-changes).
+1. The CLI can be used together with [find-changes-action](https://github.com/anttiharju/find-changes-action) to run GitHub Actions jobs or steps conditionally, while benefitting from static validation for the defined paths via [action-validator](https://github.com/mpalmer/action-validator) \[it even uses this library since v0.9.0, so results should be 1:1!\]. For more information, view the action on [GitHub Actions Marketplace](https://github.com/marketplace/actions/compare-changes).
 2. The library reimplements the [GitHub Actions Workflow syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet) so other Rust projects may check whether paths in a given workflow file match a given set of files.
 
 ## More information

--- a/docs/github/workflow_syntax.md
+++ b/docs/github/workflow_syntax.md
@@ -1,6 +1,6 @@
 # Workflow syntax
 
-From [github/docs/content/actions/reference/workflows-and-actions/workflow-syntax.md?plain=1#L1276-L1341@c1ca049](https://github.com/github/docs/blob/c1ca049106639bc87381aa16e40e35f743928246/content/actions/reference/workflows-and-actions/workflow-syntax.md?plain=1#L1276-L1341) which is covered by the **Creative Commons Attribution 4.0** license from [github/docs/LICENSE@c1ca049](https://github.com/github/docs/blob/c1ca049106639bc87381aa16e40e35f743928246/LICENSE) (also included in-repo in the adjacent [LICENSE](./LICENSE) file). Only automated formatting changes (e.g., prettier) have been applied to the content below.
+From [github/docs/content/actions/reference/workflows-and-actions/workflow-syntax.md?plain=1#L1276-L1341@c1ca049](https://github.com/github/docs/blob/c1ca049106639bc87381aa16e40e35f743928246/content/actions/reference/workflows-and-actions/workflow-syntax.md?plain=1#L1276-L1341) which is covered by the **Creative Commons Attribution 4.0** license from [github/docs/LICENSE@c1ca049](https://github.com/github/docs/blob/c1ca049106639bc87381aa16e40e35f743928246/LICENSE) (also included in-repo in the adjacent [LICENSE](./LICENSE) file). Only automated formatting changes (e.g., prettier) and issues caught by `zensical build --strict` have been applied to the content below.
 
 ## Filter pattern cheat sheet
 
@@ -32,7 +32,7 @@ branches: [ main, 'release/v[0-9].[0-9]' ]
 branches: [ main, release/v[0-9].[0-9] ]
 ```
 
-For more information about branch, tag, and path filter syntax, see [`on.<push>.<branches|tags>`](#onpushbranchestagsbranches-ignoretags-ignore), [`on.<pull_request>.<branches|tags>`](#onpull_requestpull_request_targetbranchesbranches-ignore), and [`on.<push|pull_request>.paths`](#onpushpull_requestpull_request_targetpathspaths-ignore).
+For more information about branch, tag, and path filter syntax, see [`on.<push>.<branches|tags>`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushbranchestagsbranches-ignoretags-ignore), [`on.<pull_request>.<branches|tags>`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpull_requestpull_request_targetbranchesbranches-ignore), and [`on.<push|pull_request>.paths`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore).
 
 ### Patterns to match branches and tags
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -62,6 +62,9 @@ pre-commit:
       run: nixfmt {staged_files}
       stage_fixed: true
 
+    - glob: "{docs/*,zensical.toml,flake.nix,flake.lock}"
+      run: zensical build --strict
+
     - name: zizmor
       glob: "{.github/workflows/*.yml,*/action.yml,flake.nix,flake.lock}"
       run: zizmor .


### PR DESCRIPTION
<!--This repository uses PR labels for determining the version to release:-->
<!--major-release-->
<!--minor-release-->
<!--patch-release ('dependencies' label is treated the same)-->
<!--no-release-->

mkdocs used to have it, Zensical has recently added it back. Adding it back.

* Resolves #224 