### PR TITLE
Bump actions/cache to v6 in downstream actions

### DIFF
--- a/.release/action-compare/template.yml
+++ b/.release/action-compare/template.yml
@@ -38,7 +38,7 @@ runs:
     - if: steps.binary.outputs.installed != 'true'
       name: Cache
       id: cache
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: /usr/local/bin/compare-changes
         key: compare-changes_v${{ inputs.version }}_${{ steps.convert.outputs.target }}

--- a/.release/action-find/template.yml
+++ b/.release/action-find/template.yml
@@ -28,7 +28,7 @@ runs:
     - if: steps.binary.outputs.installed != 'true'
       name: Cache
       id: cache
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: /usr/local/bin/compare-changes
         key: compare-changes_v${{ inputs.version }}_${{ steps.convert.outputs.target }}


### PR DESCRIPTION
<!--This repository uses PR labels for determining the version to release:-->
<!--major-release-->
<!--minor-release-->
<!--patch-release ('dependencies' label is treated the same)-->

too bad dependabot won't catch these